### PR TITLE
Prevents error where column counts are unequal between rows

### DIFF
--- a/R/elasticsearch.R
+++ b/R/elasticsearch.R
@@ -45,7 +45,7 @@ es.search.scroll <- function(es.hostname="http://locahost:9200",
       }
 
       hits <- transform.es.f(es.result)
-      hits.all <- rbindlist(list(hits.all, hits))
+      hits.all <- rbindlist(list(hits.all, hits), fill=TRUE)
 
       message(paste("Retrieved", nrow(es.result$hits$hits), ". Total:", nrow(hits.all)))
 


### PR DESCRIPTION
When querying data from different time period, new fields may be introduced at some point of time, which generate extra columns. This allows the merging of those two kinds of datasets, assigning "NA" to rows where the fields have no value.
